### PR TITLE
Support an undo

### DIFF
--- a/src/clj/tenkiwi/gamemasters/debrief.clj
+++ b/src/clj/tenkiwi/gamemasters/debrief.clj
@@ -449,6 +449,7 @@
         next-game          (-> game
                             (assoc-in [:inactive-display :x-card-active?] false)
                             (assoc :-deck deck
+                                   :-last-state game
                                    :-discard discard))
         new-active-display (build-active-card next-game next-card active-player next-up)]
     (assoc (merge next-game stage-info)


### PR DESCRIPTION
We noticed in the last game it might be handy to go back.

This is a heavy undo - game state will be carried in the :-last-state, which means all possible states are chained back through game state if you keep looking at nested :-last-states, rather than trying to just review the discard pile to rewind state. 

This could become taxing on duratom especially, depending on whether nippy can serialize references appropriately.

